### PR TITLE
[Makefile] Update include paths for third-party libraries; [emonCM_te…

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,7 +1,8 @@
 CC = cc
 CFLAGS = -Wall -Wpedantic -g
-INCLUDES = ../src/ -I./
+INCLUDES = ../src/ -I./ -I../third_party/qfplib/
 DEFINES = -DHOSTED
+LIBS = -lm
 
 cm: OBJS = test_cm.c ../src/emon_CM.c ../src/board_def.c
 eeprom: OBJS = test_eeprom.c ../src/eeprom.c

--- a/tests/emonCM_test.h
+++ b/tests/emonCM_test.h
@@ -24,3 +24,5 @@ float qfp_int642float(int64_t a) { return (float)a; }
 float qfp_uint2float(unsigned int a) { return (float)a; }
 
 int qfp_float2int(float a) { return (int)a; }
+
+int qfp_float2int_z(float a) { return (int)roundf(a); }


### PR DESCRIPTION
…st.h] Add rounding function for float to int conversion

Add missing "int qfp_float2int_z(float a) { return (int)roundf(a); }" in emonCM_test.h

Fix makefile for missing "-lm" and include path to qfplib